### PR TITLE
typo in file name

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from os import path
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'readme.txt')) as f:
+with open(path.join(this_directory, 'README.txt')) as f:
     long_description = f.read()
 
 setup(name='GrabzIt',


### PR DESCRIPTION
Due to a wrong filename reference in setup.py the package cannot be installed. This fixes https://github.com/GrabzIt/grabzit/issues/26